### PR TITLE
fix(html-webpack-plugin): add publicPath

### DIFF
--- a/code/html-webpack-plugin/example/build.js
+++ b/code/html-webpack-plugin/example/build.js
@@ -5,6 +5,7 @@ const compiler = webpack({
   entry: './index.js',
   output: {
     filename: '[name].[contenthash:8].js',
+    publicPath: './',
     clean: true
   },
   optimization: {


### PR DESCRIPTION
我尝试设置 {publicPath: '.' } 但是报错，文件请求路径不存在。

在生成的 runtime～main.[hash].js 文件中，引入 self.webpackChunk 时没有给  publicPath 添加可能的 "/" 后缀，而是直接使用的 '.' 参数。

于是我修改成 {publicPath: './'} 就可以了。